### PR TITLE
Add support to specify the version of PHP as a parameter

### DIFF
--- a/00-master-rc.yaml
+++ b/00-master-rc.yaml
@@ -46,6 +46,7 @@ Metadata:
         - WebInstanceType
         - WebAsgMax
         - WebAsgMin
+        - PHPVersion
     - Label:
         default: 'REDCap Source Code - Create a bucket in S3 and then upload the REDCap install zip file (e.g. redcap8.6.0.zip) to that bucket'
       Parameters:
@@ -100,6 +101,8 @@ Metadata:
         default: Minimum REDCap Instances
       WebInstanceType:
         default: Web Tier Instance Type
+      PHPVersion:
+        default: PHP Version
 
       RedcapS3Bucket:
         default: S3 Bucket
@@ -278,6 +281,17 @@ Parameters:
     Default: 2
     Description: Specifies the minimum number of EC2 instances in the Web Autoscaling Group.  A value of >1 will a highly available environment by placing instances in multiple availability zones.
     Type: String
+  
+  PHPVersion:
+    AllowedValues:
+      - 7.0
+      - 7.1
+      - 7.2
+      - 7.3
+    Default: 7.3
+    Description: The version of PHP to use with REDCap.  PHP 7.3 is recommended.
+    Type: String
+
   RedcapS3Bucket:
     Description: "The name of the S3 bucket that contains your REDCap source zip file (e.g. myredcapsourcefiles)"
     Type: String
@@ -380,6 +394,8 @@ Resources:
           !Ref WebAsgMin
         WebInstanceType:
           !Ref WebInstanceType
+        PHPVersion:
+          !Ref PHPVersion
         S3AccessKey:
           !GetAtt 'VPCStack.Outputs.S3AccessKey'
         S3SecretKey:

--- a/01-rc-vpc.yaml
+++ b/01-rc-vpc.yaml
@@ -465,6 +465,8 @@ Resources:
   EC2Role:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns: 
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -701,7 +701,7 @@ Resources:
                           if [ ! -f /eb-configured ]; then
                           
                           if [ "${PHPVersion}" = "7.0" ]; then
-                            yum install -y mysql57 php70-ldap sendmail-cf
+                            yum install -y mysql57 php70-ldap php70-zip sendmail-cf
                           fi
 
                           if [ "${PHPVersion}" = "7.1" ]; then

--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -8,9 +8,8 @@
 
 
 AWSTemplateFormatVersion: '2010-09-09'
-Description: This CloudFormation Template deploys a complete scalable REDCap environment.
-
-
+Description: This CloudFormation Template deploys a complete REDCap environment.  It
+  depends on the REDCap-vpc CloudFormation Template.
 
 Parameters:
   SESUsername:
@@ -116,6 +115,15 @@ Parameters:
     ConstraintDescription: Must be a valid Amazon EC2 instance type.
     Default: t2.micro
     Description: The Amazon EC2 instance type for your web instances.
+    Type: String
+  PHPVersion:
+    AllowedValues:
+      - 7.0
+      - 7.1
+      - 7.2
+      - 7.3
+    Default: 7.0
+    Description: The version of PHP to use with REDCap.
     Type: String
   S3FileRepositoryBucket:
     Type: String
@@ -662,9 +670,9 @@ Resources:
                           UPDATE redcap_config SET value = '${S3Bucket}' WHERE field_name = 'amazon_s3_bucket';
                           UPDATE redcap_config SET value = '${S3AccessKey}' WHERE field_name = 'amazon_s3_key';
                           UPDATE redcap_config SET value = '${S3SecretKey}' WHERE field_name = 'amazon_s3_secret'; 
-                          UPDATE redcap_config SET value = '${AWS::Region}' WHERE field_name = 'amazon_s3_endpoint';
+                          UPDATE redcap_config SET value = '${AWS::Region}' WHERE field_name = 'amazon_s3_endpoint';     
                           -- Manually set flag to indicate that this installation is being run on AWS CloudFormation
-                          REPLACE INTO redcap_config (field_name, value) VALUES ('aws_quickstart', '1');                          
+                          REPLACE INTO redcap_config (field_name, value) VALUES ('aws_quickstart', '1'); 
                           -- Add second MySQL user with user and password in *plain text* (will be auto-encrypted by REDCap afterward)
                           REPLACE INTO redcap_config (field_name, value) VALUES
                           ('redcap_updates_user', 'redcap_user2'),
@@ -692,7 +700,22 @@ Resources:
                           #only do the below tasks if it's the first deployment to this server.
                           if [ ! -f /eb-configured ]; then
                           
-                          yum install -y mysql57 php70-zip php70-ldap sendmail-cf
+                          if [ "${PHPVersion}" = "7.0" ]; then
+                            yum install -y mysql57 php70-ldap sendmail-cf
+                          fi
+
+                          if [ "${PHPVersion}" = "7.1" ]; then
+                            yum install -y mysql57 php71-ldap sendmail-cf
+                          fi
+
+                          if [ "${PHPVersion}" = "7.2" ]; then
+                            yum install -y mysql57 php72-ldap sendmail-cf
+                          fi
+
+                          if [ "${PHPVersion}" = "7.3" ]; then
+                            yum install -y mysql57 php73-ldap sendmail-cf
+                          fi                        
+                          
                           yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
                           restart amazon-ssm-agent
                           
@@ -839,6 +862,10 @@ Resources:
           yum update -y aws-cli 
           yum install -y awslogs
 
+          # Install SSM client
+          yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+          restart amazon-ssm-agent
+
           aws configure set metadata_service_timeout 10
           aws configure set metadata_service_num_attempts 5
           #Use cfn-init to grab and apply the files specified in the above UserData
@@ -860,10 +887,12 @@ Resources:
           aws s3 mb s3://${S3FileRepositoryBucket}
           aws s3api put-bucket-encryption --bucket ${S3FileRepositoryBucket} --server-side-encryption-configuration '{ "Rules": [ { "ApplyServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" } } ] }'
           #Tell Elastic Beanstalk what the latest PHP 7 solution stack is 
-          export SOLUTION_STACK=`aws elasticbeanstalk list-available-solution-stacks | grep "PHP 7" | head -1 | cut -d \" -f2`
+          echo ${PHPVersion}
+          export SOLUTION_STACK=`aws elasticbeanstalk list-available-solution-stacks | grep -v "SolutionStackName" | grep "PHP ${PHPVersion}" | head -1 | cut -d \" -f2`
+          echo $SOLUTION_STACK
           /opt/aws/bin/cfn-signal --stack ${AWS::StackName} --region ${AWS::Region} "${EC2WaitHandle}" -d "$SOLUTION_STACK"
           #Shutdown and terminate this temporary instance 
-          sleep 20
+          sleep 600
           shutdown -h now
   EC2WaitCondition:
     Type: "AWS::CloudFormation::WaitCondition"


### PR DESCRIPTION
These changes add a parameter that allow you to specify the version of PHP (7.0 - 7.3) that AWS Elastic Beanstalk uses as a parameter.  The default is 7.3.