### PR TITLE
use AWS::REGION so use ses email endpoints in same region

### DIFF
--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -742,15 +742,15 @@ Resources:
                           service httpd restart
                           
                           #sendmail configuration to enable sending e-mails
-                          makemap hash /etc/mail/authinfo.db <<< "AuthInfo:email-smtp.us-east-1.amazonaws.com \"U:root\" \"I:${SESu}\" \"P:${SESpw}\" \"M:LOGIN\""
-                          makemap hash /etc/mail/access.db <<< "Connect:email-smtp.us-east-1.amazonaws.com RELAY"
+                          makemap hash /etc/mail/authinfo.db <<< "AuthInfo:email-smtp.${AWS::Region}.amazonaws.com \"U:root\" \"I:${SESu}\" \"P:${SESpw}\" \"M:LOGIN\""
+                          makemap hash /etc/mail/access.db <<< "Connect:email-smtp.${AWS::Region}.amazonaws.com RELAY"
                           sed -i "170iFEATURE(masquerade_entire_domain)dnl" /etc/mail/sendmail.mc
                           sed -i "170iFEATURE(masquerade_envelope)dnl" /etc/mail/sendmail.mc
                           sed -i "170iMASQUERADE_AS(\`${HostedZone}')dnl" /etc/mail/sendmail.mc
                           sed -i "170iFEATURE(\`authinfo', \`hash -o /etc/mail/authinfo.db')dnl" /etc/mail/sendmail.mc
                           sed -i "170idefine(\`confAUTH_MECHANISMS', \`LOGIN PLAIN')dnl" /etc/mail/sendmail.mc
                           sed -i "170idefine(\`RELAY_MAILER_ARGS', \`TCP \$h 587')dnl" /etc/mail/sendmail.mc
-                          sed -i "170idefine(\`SMART_HOST', \`email-smtp.us-east-1.amazonaws.com')dnl" /etc/mail/sendmail.mc
+                          sed -i "170idefine(\`SMART_HOST', \`email-smtp.${AWS::Region}.amazonaws.com')dnl" /etc/mail/sendmail.mc
                           chmod 666 /etc/mail/sendmail.cf
                           m4 /etc/mail/sendmail.mc > /etc/mail/sendmail.cf
                           chmod 644 /etc/mail/sendmail.cf


### PR DESCRIPTION
Hi All,

I tried to use the stack in eu-west-1 but hit issues as I set up the SES service in eu-west-1 and the 02-rc-elasticbeanstalk.yaml stack assumes us-east-1

This change uses the SES service in the region the service is launched in.  Perhaps not ideal as SES is not available in all regions

Amazon Simple Email Service (Amazon SES) is now available in the Asia Pacific (Mumbai), Asia Pacific (Sydney), and EU (Frankfurt) Regions, in addition to the US East (Virginia), US West (Oregon), and Europe (Ireland) regions(https://aws.amazon.com/about-aws/whats-new/2019/10/amazon-ses-is-now-available-in-three-additional-aws-regions/#:~:text=Amazon%20Simple%20Email%20Service%20(Amazon,and%20Europe%20(Ireland)%20regions.)