### PR TITLE
Updated to remove unsupported PHP versions

### DIFF
--- a/00-master-rc.yaml
+++ b/00-master-rc.yaml
@@ -304,8 +304,6 @@ Parameters:
   
   PHPVersion:
     AllowedValues:
-      - 7.2
-      - 7.3
       - 7.4
       - 8.0
       - 8.1

--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -119,8 +119,6 @@ Parameters:
     Type: String
   PHPVersion:
     AllowedValues:
-      - 7.2
-      - 7.3
       - 7.4
       - 8.0
       - 8.1


### PR DESCRIPTION
Removed the ability to select PHP version 7.2 and 7.3 because those are now unsupported by AWS Elastic Beanstalk.