### PR TITLE
Address MySQL instance incompatibility challenges

### DIFF
--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -562,12 +562,11 @@ Resources:
       MasterUserPassword: !Ref DatabaseMasterPassword
       DatabaseName: 'redcap'
       Engine: aurora-mysql
+      EngineVersion: 5.7
       StorageEncrypted: 'True'
       Port: 3306
       DBSubnetGroupName:
         Ref: RDSDBSubnets
-      DBClusterParameterGroupName:
-        Ref: RDSDBClusterParameterGroup
       VpcSecurityGroupIds:
         - !Ref SGData
   RDSDBInstance1:
@@ -575,8 +574,6 @@ Resources:
     Properties:
       DBSubnetGroupName:
         Ref: RDSDBSubnets
-      DBParameterGroupName:
-        Ref: RDSDBParameterGroup
       Engine: aurora-mysql
       DBClusterIdentifier:
         Ref: RDSCluster
@@ -589,27 +586,11 @@ Resources:
     Properties:
       DBSubnetGroupName:
         Ref: RDSDBSubnets
-      DBParameterGroupName:
-        Ref: RDSDBParameterGroup
       Engine: aurora-mysql
       DBClusterIdentifier:
         Ref: RDSCluster
       PubliclyAccessible: 'false'
       DBInstanceClass: !Ref DatabaseInstanceType
-  RDSDBClusterParameterGroup:
-    Type: AWS::RDS::DBClusterParameterGroup
-    Properties:
-      Description: CloudFormation Sample Aurora Cluster Parameter Group
-      Family: aurora-mysql5.7
-      Parameters:
-        time_zone: US/Eastern
-  RDSDBParameterGroup:
-    Type: AWS::RDS::DBParameterGroup
-    Properties:
-      Description: CloudFormation Sample Aurora Parameter Group
-      Family: aurora-mysql5.7
-      Parameters:
-        sql_mode: IGNORE_SPACE
   RDSDBSubnets:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
@@ -617,7 +598,6 @@ Resources:
       SubnetIds:
         - !Ref SubnetDataA
         - !Ref SubnetDataB
-
 
 
 


### PR DESCRIPTION
This change loosens the Aurora MySQL Engine version definition to allow the latest minor versions to be used and resolves a recent incompatibility with certain RDS instance types.