### PR TITLE
Modifying code to use custom Parameter groups for RDS

### DIFF
--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -567,6 +567,8 @@ Resources:
       Port: 3306
       DBSubnetGroupName:
         Ref: RDSDBSubnets
+      DBClusterParameterGroupName:
+        Ref: RDSDBClusterParameterGroup
       VpcSecurityGroupIds:
         - !Ref SGData
   RDSDBInstance1:
@@ -574,6 +576,8 @@ Resources:
     Properties:
       DBSubnetGroupName:
         Ref: RDSDBSubnets
+      DBParameterGroupName:
+        Ref: RDSDBParameterGroup
       Engine: aurora-mysql
       DBClusterIdentifier:
         Ref: RDSCluster
@@ -586,11 +590,27 @@ Resources:
     Properties:
       DBSubnetGroupName:
         Ref: RDSDBSubnets
+      DBParameterGroupName:
+        Ref: RDSDBParameterGroup
       Engine: aurora-mysql
       DBClusterIdentifier:
         Ref: RDSCluster
       PubliclyAccessible: 'false'
       DBInstanceClass: !Ref DatabaseInstanceType
+  RDSDBClusterParameterGroup:
+    Type: AWS::RDS::DBClusterParameterGroup
+    Properties:
+      Description: CloudFormation Sample Aurora Cluster Parameter Group
+      Family: aurora-mysql5.7
+      Parameters:
+        time_zone: US/Eastern
+  RDSDBParameterGroup:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: CloudFormation Sample Aurora Parameter Group
+      Family: aurora-mysql5.7
+      Parameters:
+        sql_mode: IGNORE_SPACE
   RDSDBSubnets:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
@@ -598,6 +618,7 @@ Resources:
       SubnetIds:
         - !Ref SubnetDataA
         - !Ref SubnetDataB
+
 
 
 


### PR DESCRIPTION
Previous commit [https://github.com/vanderbilt-redcap/redcap-aws-cloudformation/pull/32](https://github.com/vanderbilt-redcap/redcap-aws-cloudformation/pull/32) fixed Mysql incompatible issues but its using default parameter group we are unable to modify default parameter group if we want to add additional param. This commit will fix that issue.