### PR TITLE
Update 02-rc-elasticbeanstalk.yaml

### DIFF
--- a/02-rc-elasticbeanstalk.yaml
+++ b/02-rc-elasticbeanstalk.yaml
@@ -325,6 +325,9 @@ Resources:
         Version: ' '
       OptionSettings:
         - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: RootVolumeType
+          Value: gp3
+        - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: IamInstanceProfile
           Value: !Ref EBInstanceProfile 
         - Namespace: 'aws:elasticbeanstalk:environment'
@@ -345,8 +348,8 @@ Resources:
         - Namespace: aws:autoscaling:launchconfiguration
           OptionName: EC2KeyName
           Value: !Ref 'EC2KeyName'
-        - Namespace: aws:autoscaling:launchconfiguration
-          OptionName: InstanceType
+        - Namespace: aws:ec2:instances
+          OptionName: InstanceTypes
           Value: !Ref WebInstanceType
         - Namespace: aws:autoscaling:launchconfiguration
           OptionName: SecurityGroups
@@ -452,6 +455,9 @@ Resources:
         Version: ' '
       OptionSettings:
         - Namespace: 'aws:autoscaling:launchconfiguration'
+          OptionName: RootVolumeType
+          Value: gp3
+        - Namespace: 'aws:autoscaling:launchconfiguration'
           OptionName: IamInstanceProfile
           Value: !Ref EBInstanceProfile 
         - Namespace: 'aws:elasticbeanstalk:environment'
@@ -472,8 +478,8 @@ Resources:
         - Namespace: aws:autoscaling:launchconfiguration
           OptionName: EC2KeyName
           Value: !Ref 'EC2KeyName'
-        - Namespace: aws:autoscaling:launchconfiguration
-          OptionName: InstanceType
+        - Namespace: aws:ec2:instances
+          OptionName: InstanceTypes
           Value: !Ref WebInstanceType
         - Namespace: aws:autoscaling:launchconfiguration
           OptionName: SecurityGroups


### PR DESCRIPTION
AWS has deprecated the use of Launch Configuration in EC2 for new customers. I have updated the template to use Launch templates instead. I have tested on new deployment and existing.